### PR TITLE
Can still extract weights when a learner fails

### DIFF
--- a/R/estimators.R
+++ b/R/estimators.R
@@ -79,9 +79,7 @@ lmtp_tmle <- function(data, trt, outcome, nodes, baseline = NULL,
     outcome_type = match.arg(outcome_type),
     V = folds,
     bounds = bounds,
-    bound = bound,
-    count_lrnrs_outcome = count_lrnrs(learners_outcome),
-    count_lrnrs_trt = count_lrnrs(learners_trt)
+    bound = bound
   )
 
   pb <- progressr::progressor(meta$tau*folds*2)
@@ -202,9 +200,7 @@ lmtp_sdr <- function(data, trt, outcome, nodes, baseline = NULL,
     outcome_type = match.arg(outcome_type),
     V = folds,
     bounds = bounds,
-    bound = bound,
-    count_lrnrs_outcome = count_lrnrs(learners_outcome),
-    count_lrnrs_trt = count_lrnrs(learners_trt)
+    bound = bound
   )
 
   pb <- progressr::progressor(meta$tau*folds*2)
@@ -316,9 +312,7 @@ lmtp_sub <- function(data, trt, outcome, nodes, baseline = NULL,
     outcome_type = match.arg(outcome_type),
     V = folds,
     bounds = bounds,
-    bound = bound,
-    count_lrnrs_outcome = count_lrnrs(learners),
-    count_lrnrs_trt = 0
+    bound = bound
   )
 
   pb <- progressr::progressor(meta$tau*folds)
@@ -414,9 +408,7 @@ lmtp_ipw <- function(data, trt, outcome, nodes, baseline = NULL,
     outcome_type = NULL,
     V = folds,
     bounds = NULL,
-    bound = bound,
-    count_lrnrs_outcome = 0,
-    count_lrnrs_trt = count_lrnrs(learners)
+    bound = bound
   )
 
   pb <- progressr::progressor(meta$tau*folds)

--- a/R/m-engine.R
+++ b/R/m-engine.R
@@ -22,7 +22,7 @@ estimate_sub <- function(training, shifted, validation, outcome,
 
     # run SL
     fit <- run_ensemble(ensemble, fit_task)
-    sl_weights[tau, ] <- extract_sl_weights(fit)
+    sl_weights[[tau]] <- extract_sl_weights(fit)
 
     # predict on shifted data for training
     training[js, pseudo] <- bound(predict_sl3(fit, shift_task))
@@ -80,7 +80,7 @@ estimate_tmle <- function(training, shifted, validation, validation_shifted,
 
     # run SL
     fit <- run_ensemble(ensemble, fit_task)
-    sl_weights[tau, ] <- extract_sl_weights(fit)
+    sl_weights[[tau]] <- extract_sl_weights(fit)
 
     # predict on data
     m_natural$train[jt, tau] <- bound(predict_sl3(fit, nshift_task))
@@ -159,7 +159,7 @@ estimate_sdr <- function(training, shifted, validation, validation_shifted,
 
       # run SL
       fit <- run_ensemble(ensemble, fit_task)
-      sl_weights[tau, ] <- extract_sl_weights(fit)
+      sl_weights[[tau]] <- extract_sl_weights(fit)
 
       # predict on training data
       m_natural$train[jt, tau] <- bound(predict_sl3(fit, nshift_task))
@@ -191,7 +191,7 @@ estimate_sdr <- function(training, shifted, validation, validation_shifted,
 
       # run SL
       fit <- run_ensemble(ensemble, fit_task)
-      sl_weights[tau, ] <- extract_sl_weights(fit)
+      sl_weights[[tau]] <- extract_sl_weights(fit)
 
       # predictions
       m_natural$train[jt, tau] <- bound(predict_sl3(fit, nshift_task))

--- a/R/prepare-estimators.R
+++ b/R/prepare-estimators.R
@@ -17,7 +17,7 @@ Meta <- R6::R6Class(
     weights_r = NULL,
     initialize = function(data, trt, outcome, nodes, baseline, cens, k,
                           shift, outcome_type = NULL, V = 10, bounds = NULL,
-                          bound = NULL, count_lrnrs_outcome, count_lrnrs_trt) {
+                          bound = NULL) {
 
       # initial checks
       check_censoring(data, cens, final_outcome(outcome))
@@ -69,8 +69,8 @@ Meta <- R6::R6Class(
           ), folds
         )
 
-      self$weights_m <- create_lrnr_matrix(V, length(nodes), count_lrnrs_outcome)
-      self$weights_r <- create_lrnr_matrix(V, length(nodes), count_lrnrs_trt)
+      self$weights_m <- hold_lrnr_weights(V)
+      self$weights_r <- hold_lrnr_weights(V)
     }
   )
 )

--- a/R/r-engine.R
+++ b/R/r-engine.R
@@ -25,7 +25,7 @@ estimate_r <- function(training, validation, trt, cens, deterministic, shift,
 
     # run SL
     fit             <- run_ensemble(ensemble, fit_task)
-    sl_weights[t, ] <- extract_sl_weights(fit)
+    sl_weights[[t]] <- extract_sl_weights(fit)
 
     # ratios training
     pred            <- bound(predict_sl3(fit, tpred_task), .Machine$double.eps)

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,36 +126,12 @@ recombine_dens_ratio <- function(r) {
   return(Reduce(rbind, lapply(r, function(x) x[["valid"]])))
 }
 
-create_lrnr_matrix <- function(folds, tau, lrnrs) {
-  # create empty matrices
-  lrnrs <- ifelse(lrnrs == 0, 2, lrnrs)
-  out <- lapply(1:folds, function(x) matrix(nrow = tau, ncol = lrnrs))
-
-  # set matrix names
-  names(out) <- paste0("fold_", 1:folds)
-  for (i in 1:length(out)) {
-    rownames(out[[i]]) <- paste0("time_", 1:tau)
-    colnames(out[[i]]) <- paste0("Lrnr_", 1:lrnrs)
-  }
-
-  return(out)
+hold_lrnr_weights <- function(folds) {
+  lapply(1:folds, function(x) list())
 }
 
 extract_sl_weights <- function(fit) {
-  fit$fit_object$full_fit$learner_fits$Lrnr_nnls_TRUE$coefficients
-}
-
-count_lrnrs <- function(lrnr) {
-
-  if (is.null(lrnr)) {
-    return(2)
-  }
-
-  out <- length(lapply(lrnr$params$learners, function(x) x$name))
-  if (out == 0) {
-    out <- 1
-  }
-  return(out)
+  as.data.frame(fit$fit_object$full_fit$learner_fits$Lrnr_nnls_TRUE$fits)
 }
 
 pluck_weights <- function(type, x) {


### PR DESCRIPTION
This PR addresses issue #34. Estimators should no longer fail when an sl3 learner fails when ensemble weights are extracted. 