### PR TITLE
updated checks with tau

### DIFF
--- a/R/prepare-estimators.R
+++ b/R/prepare-estimators.R
@@ -25,7 +25,7 @@ Meta <- R6::R6Class(
       # initial checks
       check_for_variables(data, trt, outcome, baseline, time_vary, cens)
       check_censoring(data, cens, final_outcome(outcome))
-      check_missing_data(data, trt, time_vary, baseline, cens, tau)
+      check_missing_data(data, trt, outcome, time_vary, baseline, cens, tau)
       check_scaled_conflict(data)
       check_folds(V)
       check_time_vary(time_vary)
@@ -33,7 +33,7 @@ Meta <- R6::R6Class(
       # general setup
       self$n            <- nrow(data)
       self$tau          <- tau
-      self$trt          <- check_trt_length(trt, tau)
+      self$trt          <- check_trt_length(trt, time_vary, cens, tau)
       self$determ       <- check_deterministic(outcome, tau)
       self$node_list    <- create_node_list(trt, tau, time_vary, baseline, k)
       self$outcome_type <- outcome_type

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -31,3 +31,17 @@ test_that("time_vary is a list", {
   expect_error(lmtp_sub(sim_cens, a, "Y", nodes, baseline = NULL,
                         cens, k = 1, shift = function(x) x + 0.5))
 })
+
+test_that("variable length mismatch", {
+  a <- c("A1")
+  nodes <- list(c("L1"), c("L2"))
+  cens <- c("C1", "C2")
+  expect_error(lmtp_sub(sim_cens, a, "Y", nodes, baseline = NULL,
+                        cens, k = 1, shift = function(x) x + 0.5))
+
+  a <- c("A1", "A2")
+  nodes <- list(c("L1"))
+  expect_error(lmtp_sub(sim_cens[complete.cases(sim_cens), ], a, "Y",
+                        nodes, baseline = NULL, k = 1, shift = function(x) x + 0.5))
+
+})


### PR DESCRIPTION
Improves upon the checking that there is consistent lengths among the `trt`, `time_vary`, and `cens` parameters. Should more directly point the analyst to the problematic parameter. Solves issue #64 