### PR TITLE
updated sl3 version to handle competing risks

### DIFF
--- a/R/checks-warnings.R
+++ b/R/checks-warnings.R
@@ -161,15 +161,21 @@ check_trt_length <- function(trt, time_vary = NULL, cens = NULL, tau) {
   rep(trt, tau)
 }
 
-check_at_risk <- function(outcomes, tau) {
+check_at_risk <- function(outcomes, tau, comp_risks) {
   if (length(outcomes) == 1) {
     return(NULL)
   }
-
+  
+  # if there's a competing risk, return a risk object that's a list instead of vector
+  if (length(outcomes) == tau & !is.null(comp_risks)) {
+    return(list("outcome" = outcomes[1:tau - 1],
+                "comp_risk" = comp_risks[1:tau - 1]))
+  }
+  
   if (length(outcomes) == tau) {
     return(outcomes[1:tau - 1])
   }
-
+  
   stop("It appears there is a mismatch between the length of `outcome` and other parameters.",
        call. = FALSE)
 }

--- a/R/estimators.R
+++ b/R/estimators.R
@@ -68,7 +68,7 @@
 #' @example inst/examples/tmle-ex.R
 #' @export
 lmtp_tmle <- function(data, trt, outcome, baseline = NULL, time_vary = NULL,
-                      cens = NULL, shift = NULL, shifted = NULL, k = Inf,
+                      cens = NULL, comp_risk = NULL, shift = NULL, shifted = NULL, k = Inf,
                       intervention_type = c("static", "dynamic", "mtp"),
                       outcome_type = c("binomial", "continuous", "survival"),
                       id = NULL, bounds = NULL,
@@ -93,7 +93,8 @@ lmtp_tmle <- function(data, trt, outcome, baseline = NULL, time_vary = NULL,
     V = folds,
     weights = weights,
     bounds = bounds,
-    bound = .bound
+    bound = .bound,
+    comp_risk = comp_risk
   )
 
   pb <- progressr::progressor(meta$tau*folds*2)
@@ -218,7 +219,7 @@ lmtp_tmle <- function(data, trt, outcome, baseline = NULL, time_vary = NULL,
 #'
 #' @example inst/examples/sdr-ex.R
 lmtp_sdr <- function(data, trt, outcome, baseline = NULL, time_vary = NULL,
-                     cens = NULL, shift = NULL, shifted = NULL, k = Inf,
+                     cens = NULL, comp_risk = NULL, shift = NULL, shifted = NULL, k = Inf,
                      intervention_type = c("static", "dynamic", "mtp"),
                      outcome_type = c("binomial", "continuous", "survival"),
                      id = NULL, bounds = NULL,
@@ -243,7 +244,8 @@ lmtp_sdr <- function(data, trt, outcome, baseline = NULL, time_vary = NULL,
     V = folds,
     weights = NULL,
     bounds = bounds,
-    bound = .bound
+    bound = .bound,
+    comp_risk = comp_risk
   )
 
   pb <- progressr::progressor(meta$tau*folds*2)
@@ -357,7 +359,7 @@ lmtp_sdr <- function(data, trt, outcome, baseline = NULL, time_vary = NULL,
 #' @export
 #'
 #' @example inst/examples/sub-ex.R
-lmtp_sub <- function(data, trt, outcome, baseline = NULL, time_vary = NULL, cens = NULL,
+lmtp_sub <- function(data, trt, outcome, baseline = NULL, time_vary = NULL, cens = NULL, comp_risk = NULL,
                      shift = NULL, shifted = NULL, k = Inf,
                      outcome_type = c("binomial", "continuous", "survival"),
                      id = NULL, bounds = NULL, learners = sl3::make_learner(sl3::Lrnr_glm),
@@ -366,6 +368,7 @@ lmtp_sub <- function(data, trt, outcome, baseline = NULL, time_vary = NULL, cens
     data = data,
     trt = trt,
     outcome = outcome,
+    comp_risk = comp_risk,
     time_vary = time_vary,
     baseline = baseline,
     cens = cens,
@@ -474,7 +477,7 @@ lmtp_sub <- function(data, trt, outcome, baseline = NULL, time_vary = NULL, cens
 #'
 #' @example inst/examples/ipw-ex.R
 lmtp_ipw <- function(data, trt, outcome, baseline = NULL, time_vary = NULL, cens = NULL,
-                     shift = NULL, shifted = NULL,
+                     comp_risk = NULL, shift = NULL, shifted = NULL,
                      intervention_type = c("static", "dynamic", "mtp"),
                      k = Inf, id = NULL,
                      outcome_type = c("binomial", "continuous", "survival"),
@@ -485,6 +488,7 @@ lmtp_ipw <- function(data, trt, outcome, baseline = NULL, time_vary = NULL, cens
     data = data,
     trt = trt,
     outcome = outcome,
+    comp_risk = comp_risk,
     time_vary = time_vary,
     baseline = baseline,
     cens = cens,

--- a/R/prepare-estimators.R
+++ b/R/prepare-estimators.R
@@ -17,7 +17,7 @@ Meta <- R6::R6Class(
     weights = NULL,
     weights_m = NULL,
     weights_r = NULL,
-    initialize = function(data, trt, outcome, time_vary, baseline, cens, k,
+    initialize = function(data, trt, outcome, comp_risk, time_vary, baseline, cens, k,
                           shift, shifted, learners_trt, learners_outcome, id,
                           outcome_type = NULL, V = 10, weights = NULL,
                           bounds = NULL, bound = NULL) {
@@ -35,7 +35,7 @@ Meta <- R6::R6Class(
 
       self$n <- nrow(data)
       self$trt <- check_trt_length(trt, time_vary, cens, self$tau)
-      self$risk <- check_at_risk(outcome, self$tau)
+      self$risk <- check_at_risk(outcome, self$tau, comp_risk)
       self$node_list <- create_node_list(trt, self$tau, time_vary, baseline, k)
       self$outcome_type <- ifelse(outcome_type %in% c("binomial", "survival"), "binomial", "continuous")
       self$survival <- outcome_type == "survival"

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,12 +63,28 @@ at_risk <- function(data, risk, tau) {
   if (is.null(risk)) {
     return(rep(TRUE, nrow(data)))
   }
-
+  
   if (tau == 1) {
     return(rep(TRUE, nrow(data)))
   }
-
-  data[[risk[tau - 1]]] == 1 & !is.na(data[[risk[tau - 1]]])
+  
+  if (is.list(risk)){
+    # if there is a competing risk, so return T/F w/ same logic as usual
+    # but with the additional logic that the competing risk has not occurred yet
+    return(data[[risk$outcome[tau - 1]]] == 1 &
+             data[[risk$comp_risk[tau - 1]]] == 0 &
+             !is.na(data[[risk$outcome[tau - 1]]]))
+  }
+  
+  if(!is.list(risk)){
+    # when there's no competing risk,
+    #return T if the outcome hasn't happened (Y == 1, pkg flips internally)
+    # and censoring hasn't occurred
+    return(data[[risk[tau - 1]]] == 1 & !is.na(data[[risk[tau - 1]]]))
+    
+  }
+  
+  
 }
 
 followed_rule <- function(obs_trt, shifted_trt, intervention_type) {


### PR DESCRIPTION
Added a new parameter `comp_risk` to `lmtp_*` estimators. This is a longitudinal indicator variable similar to `outcome` in time to event settings. The indicator affects the at-risk subset of data for estimation.