### PR TITLE
Fix error with assigning null to under shift dataframes

### DIFF
--- a/R/gcomp.R
+++ b/R/gcomp.R
@@ -62,10 +62,10 @@ estimate_sub <- function(natural, shifted, outcome, node_list, cens, risk,
     }
 
     trt_var <- names(shifted$train)[t]
-    under_shift_train <- natural$train[jt & rt, vars]
+    under_shift_train <- as.data.frame(natural$train[jt & rt, vars])
     under_shift_train[[trt_var]] <- shifted$train[jt & rt, trt_var]
 
-    under_shift_valid <- natural$valid[jv & rv, vars]
+    under_shift_valid <- as.data.frame(natural$valid[jv & rv, vars])
     under_shift_valid[[trt_var]] <- shifted$valid[jv & rv, trt_var]
 
     natural$train[jt & rt, pseudo] <- bound(SL_predict(fit, under_shift_train), 1e-05)

--- a/R/sdr.R
+++ b/R/sdr.R
@@ -83,10 +83,10 @@ estimate_sdr <- function(natural, shifted, outcome, node_list, cens, risk, tau,
     }
 
     trt_var <- names(shifted$train)[t]
-    under_shift_train <- natural$train[jt & rt, vars]
+    under_shift_train <- as.data.frame(natural$train[jt & rt, vars])
     under_shift_train[[trt_var]] <- shifted$train[jt & rt, trt_var]
 
-    under_shift_valid <- natural$valid[jv & rv, vars]
+    under_shift_valid <- as.data.frame(natural$valid[jv & rv, vars])
     under_shift_valid[[trt_var]] <- shifted$valid[jv & rv, trt_var]
 
     m_natural_train[jt & rt, t] <- bound(SL_predict(fit, natural$train[jt & rt, vars]), 1e-05)

--- a/R/tmle.R
+++ b/R/tmle.R
@@ -67,10 +67,10 @@ estimate_tmle <- function(natural, shifted, outcome, node_list, cens, risk, tau,
     }
 
     trt_var <- names(shifted$train)[t]
-    under_shift_train <- natural$train[jt & rt, vars]
+    under_shift_train <- as.data.frame(natural$train[jt & rt, vars])
     under_shift_train[[trt_var]] <- shifted$train[jt & rt, trt_var]
 
-    under_shift_valid <- natural$valid[jv & rv, vars]
+    under_shift_valid <- as.data.frame(natural$valid[jv & rv, vars])
     under_shift_valid[[trt_var]] <- shifted$valid[jv & rv, trt_var]
 
     m_natural_train[jt & rt, t] <- bound(SL_predict(fit, natural$train[jt & rt, vars]), 1e-05)


### PR DESCRIPTION
Hi Nick,

I was getting some errors with `lmtp_{sdr, tmle, sub}` when the input data is a `tbl_df`/`tbl`:
```
Error in `[[<-`(`*tmp*`, trt_var, value = NULL) : 
  Can't assign column with `trt_var`.
✖ Subscript `trt_var` must be a location, not a character `NA`.
```

Not sure if what I have suggested is the best fix for this, but it's one that worked for me.  You could also assert the type of the input data is `data.frame`.

Example to replicate the error:
```R
library(lmtp)
library(tibble)
A <- "trt"
Y <- paste0("Y.", 1:6)
C <- paste0("C.", 0:5)
W <- c("W1", "W2")
lmtp_{sdr, tmle, sub}(sim_point_surv |> tibble(), A, Y, W, cens = C, folds = 2,
                      shift = static_binary_on, outcome_type = "survival")
```

To illustrate root of error:
```R
rdf <- data.frame()
rdf[[as.character(NA)]] <- NULL  # This is fine; it will do nothing

tdf <- tibble()
tdf[[as.character(NA)]] <- NULL  # This will error as lmtp does
```