### PR TITLE
Updated EIF to consistently account for sporadic measurement weights

### DIFF
--- a/R/curve.R
+++ b/R/curve.R
@@ -110,10 +110,10 @@ estimate_curve_sdr <- function(task, fold, ratios, sporadic_weights, learners, c
 
       if (s == t) {
         # If the smallest time point in the sequence from t:tau use validation data to calculate EIF for theta at time t
-        influence_functions[, t] <- eif(ratios$valid, sporadic_weights$valid, msv[[s]], mnv[[s]], t = 1, tau = tau, l = t)
+        influence_functions[, t] <- eif(ratios$valid, sporadic_weights$valid, msv[[s]], mnv[[s]], t = 1, tau = tau)
       } else {
         # Otherwise calculate the DR transformation using training values as the pseudo outcome for the next iteration
-        dr_transformation <- eif(ratios$train, sporadic_weights$train, mst[[s]], mnt[[s]], t = (s - t + 1), tau = tau, l = t)
+        dr_transformation <- eif(ratios$train, sporadic_weights$train, mst[[s]], mnt[[s]], t = (s - t + 1), tau = tau)
         pseudo[[length(pseudo) + 1]] <- dr_transformation
       }
     }

--- a/R/eif.R
+++ b/R/eif.R
@@ -1,7 +1,6 @@
-eif <- function(density_ratios, sporadic_weights, shifted, natural, t, tau, l) {
+eif <- function(density_ratios, sporadic_weights, shifted, natural, t, tau) {
   if (missing(tau)) tau <- ncol(density_ratios)
   if (missing(t)) t <- 1
-  if (missing(l)) l <- NULL
 
   # natural[is.na(natural)] <- -999
   # shifted[is.na(shifted)] <- -999
@@ -12,26 +11,17 @@ eif <- function(density_ratios, sporadic_weights, shifted, natural, t, tau, l) {
   }
 
   m <- shifted[, (t + 1):(tau + 1), drop = FALSE] - natural[, t:tau, drop = FALSE]
-  weights <- compute_weights(density_ratios, sporadic_weights, t, tau, l)
+  weights <- compute_weights(density_ratios, sporadic_weights, t, tau)
   rowSums(weights * m, na.rm = TRUE) + shifted[, t]
 }
 
-compute_weights <- function(density_ratios, sporadic_weights, t, tau, l) {
-  # If sporadic_weights is NULL, not in curve algorithm and set to 1
-  if (is.null(sporadic_weights)) {
-    ipw_sporadic <- 1
+compute_weights <- function(density_ratios, sporadic_weights, t, tau) {
+  # Sporadic weights only effect the final density ratio
+  if (!is.null(sporadic_weights)) {
+    density_ratios[, tau] <- density_ratios[, tau] * sporadic_weights[, tau]
   }
 
-  # We only use the sporadic weights if in the first loop of the curve algorithm, l = 1
-  else if (l > 1 || is.null(l)) {
-    ipw_sporadic <- 1
-  }
-
-  else {
-    ipw_sporadic <- sporadic_weights[, t:tau, drop = FALSE]
-  }
-
-  out <- t(apply(density_ratios[, t:tau, drop = FALSE]*ipw_sporadic, 1, cumprod))
+  out <- t(apply(density_ratios[, t:tau, drop = FALSE], 1, cumprod))
   if (ncol(out) > ncol(density_ratios)) return(t(out))
   out
 }


### PR DESCRIPTION
This updates the EIF to incorporate the sporadic outcome weights as a multiplier on the final density ratio, corresponding to the (m_{tau + 1} - m_{\tau}) = (Y - m_{\tau}) residual. This reweighting needs to happen whenever the EIF is computed, including at all iterations of the SDR curve algorithm. Based on simulations this seems to yield an EIF with good empirical coverage. 