### PR TITLE
Flip

### DIFF
--- a/R/flip_helper.R
+++ b/R/flip_helper.R
@@ -1,0 +1,65 @@
+# --- Helper functions for flip effect estimation --- #
+define_flip_functions <- function(overlap, trimming_threshold, smoothing_constant) {
+  if (overlap) {
+    # Overlap weights
+    flip_func       <- function(p) p * (1 - p)
+    flip_func_deriv <- function(p) 1 - 2 * p
+  } else {
+    # Smooth trimming
+    flip_func <- function(p) {
+      if (trimming_threshold == 0) {
+        1 - exp(-smoothing_constant * p)
+      } else {
+        p / (p + exp(-smoothing_constant * (p - trimming_threshold)))
+      }
+    }
+    flip_func_deriv <- function(p) {
+      if (trimming_threshold == 0) {
+        smoothing_constant * exp(-smoothing_constant * p)
+      } else {
+        (smoothing_constant * p - 1) * exp(smoothing_constant * (trimming_threshold - p)) / 
+          ((exp(trimming_threshold * smoothing_constant) + p * exp(smoothing_constant * p))^2)
+      }
+    }
+  }
+  return(list(flip_func, flip_func_deriv))
+}
+
+compute_q_phi_scores <- function(task, prop_scores, target_regime, flip_func, flip_func_deriv) {
+  
+  # Helper functions: set 0/0 = 0. 
+  safe_divide <- function(a,b) { x <- a/b; x[is.nan(x)] <- 0; x }
+  
+  # Initialize q_scores and ratios
+  q_scores <- matrix(NA_real_, nrow = nrow(prop_scores), ncol = ncol(prop_scores))
+  ratios <- matrix(NA_real_, nrow = nrow(prop_scores), ncol = ncol(prop_scores))
+  phi_scores <- array(NA_real_, dim = c(nrow(prop_scores), ncol(prop_scores), 2))
+  
+  for (t in 1:task$tau) {
+    
+    target_tx <- target_regime[t]
+    A_t <- task$natural[,c(task$vars$A[[t]])]
+    
+    flip_p  <- flip_func(prop_scores[, t] * target_tx +
+                           (1 - prop_scores[, t]) * (1 - target_tx))
+    flip_p_deriv <- flip_func_deriv(prop_scores[, t] * target_tx +
+                                      (1 - prop_scores[, t]) * (1 - target_tx))
+    
+    q_scores[, t] <- prop_scores[, t] * (1 - flip_p) + (target_tx == 1) * flip_p
+    
+    ratios[, t] <- 
+      safe_divide(q_scores[, t] * A_t + (1 - q_scores[, t]) * (1 - A_t), 
+                  prop_scores[, t] * A_t + (1 - prop_scores[, t]) * (1 - A_t))
+    
+    # phi_scores
+    for (lvl in 0:1) {
+      phi_scores[, t, lvl + 1] <- (2 * (lvl == target_tx) - 1) *
+        ((A_t == target_tx) - (prop_scores[, t] * A_t + (1 - prop_scores[, t]) * (1 - A_t))) *
+        (1 - flip_p + flip_p_deriv * (prop_scores[, t] * (1 - A_t) + (1 - prop_scores[, t]) * A_t))
+    }
+  }
+  
+  return(list("q_scores" = q_scores,
+              "ratios" = ratios,
+              "phi_scores" = phi_scores))
+}

--- a/R/flip_sdr.R
+++ b/R/flip_sdr.R
@@ -1,16 +1,354 @@
-flip_sdr <- function(data, trt, outcome, baseline = NULL,
-                     time_vary = NULL,
-                     cens = NULL, compete = NULL,
-                     overlap = FALSE, # if FALSE, use smooth trimming, else use overlap weights
-                     trimming_threshold, #epsilon
-                     smoothing_constant, # k
-                     k = Inf,
-                     outcome_type = c("binomial", "continuous", "survival"),
-                     id = NULL, bounds = NULL,
-                     learners_outcome = "SL.glm",
-                     learners_trt = "SL.glm",
-                     folds = 10, weights = NULL,
-                     control = lmtp_control(),
+#' @title Flip SDR Estimator
+#' @description
+#' Estimate the “flip” effect via a sequentially doubly robust (SDR) procedure that 
+#' applies either smooth trimming or overlap weighting at each time point.
+#'
+#' @param data               A \code{data.frame} containing all relevant variables.
+#' @param trt                Character vector of treatment column names (time‐varying, each ending in \code{"_tXX"}).
+#' @param outcome            Name of the outcome column (character).
+#' @param baseline           Character vector of baseline covariate names, or \code{NULL} if none.
+#' @param time_vary          Character vector of time‐varying covariate names (each ending in \code{"_tXX"}), or \code{NULL}.
+#' @param cens               Name of the censoring indicator column (character), or \code{NULL} if no censoring.
+#' @param compete            Name of the competing event indicator column (character), or \code{NULL} if none.
+#' @param target_regime      Vector or list specifying the target treatment regime at each time point.
+#'                           Must have length equal to \code{length(trt)} (or \code{task$tau} internally).
+#' @param overlap            Logical; if \code{TRUE}, use overlap weights, otherwise use smooth trimming.
+#' @param trimming_threshold Numeric threshold for smooth trimming. Values outside
+#'                           this threshold receive zero weight under smooth trimming.
+#'                           Ignored if \code{overlap = TRUE}.
+#' @param smoothing_constant Numeric smoothing parameter (larger values --> weight function is closer to a 
+#'                           hard indicator). Ignored if \code{overlap = TRUE}.
+#' @param k                  Integer (or \code{Inf}); history window size. If \code{Inf}, use the full history.
+#' @param outcome_type       Character; one of \code{c("binomial", "continuous", "survival")}.
+#'                           Determines how pseudo‐outcomes are constructed and whether bounding applies.
+#' @param id                 Name of the subject‐identifier column (character), or \code{NULL}.  
+#'                           If \code{NULL}, no ID is stored in the returned \code{ife} object.
+#' @param bounds             Optional numeric vector of length 2 (\code{c(lower, upper)}) giving 
+#'                           outcome bounds. If \code{NULL}, no bounding is enforced on regression fits.
+#' @param learners_outcome   Character vector of SuperLearner (or other) learners to use for the
+#'                           sequential outcome regression steps.
+#' @param learners_trt       Character vector of SuperLearner (or other) learners to use for
+#'                           the time‐varying treatment (propensity) models.
+#' @param folds              Integer ≥ 2; number of cross‐fitting folds for both propensity and
+#'                           outcome regressions.
+#' @param weights            Optional numeric vector of sample weights (length = \code{nrow(data)}).
+#'                           If \code{NULL}, no sample weighting is applied.
+#' @param control            An \code{lmtp_control} object controlling learner options, 
+#'                           parallelization, and other fitting parameters.
+#' @param life               Logical; if \code{TRUE}, the returned list will also include
+#'                           \code{$task} (the \code{LmtpTask} object) and \code{$control}, so that
+#'                           one can continue estimation via \code{flip_sdr_second_PO} or
+#'                           \code{flip_sdr_treatment}. If \code{FALSE} (default), only final
+#'                           outputs are returned.
+#'
+#' @return A list of class \code{flip} containing:
+#' \describe{
+#'   \item{\code{estimator}}{Character; the string \code{"SDR"} indicating this is the SDR flip estimator.}
+#'   \item{\code{ifvalues}}{Numeric vector of length \code{nrow(data)} containing the final
+#'                          pseudo‐outcome (influence‐function) values at time $t = 1$ after back‐substitution.}
+#'   \item{\code{estimate}}{An \code{\link[ife]{ife}} object with 
+#'                          \code{x = mean(ifvalues)} and \code{eif = ifvalues}, indexed by \code{id} if provided.}
+#'   \item{\code{prop_scores}}{Numeric matrix of dimension $n \times \tau$, containing the cross‐fitted
+#'                          estimated propensity scores at each time point.}
+#'   \item{\code{fits_prop}}{A list of length \code{folds}, where each entry is itself a list of fitted
+#'                          propensity‐model objects (one per time point) from \code{cf_propensity}.}
+#'   \item{\code{fits_m}}{A list of length $\tau$, where each entry is the list of fitted outcome‐regression
+#'                        objects (one per fold) returned by \code{cf_sequential_regression()} at that time point.}
+#'   \item{\code{outcome_type}}{Character; same as the \code{outcome_type} argument, indicating \code{"binomial"}, 
+#'                             \code{"continuous"}, or \code{"survival"}.}
+#'   \item{\code{task}}{(Only if \code{life = TRUE}.) The \code{LmtpTask} object constructed internally,
+#'                      containing original data, shift plan, and relevant metadata (used for continuation).}
+#'   \item{\code{control}}{(Only if \code{life = TRUE}.) The \code{lmtp_control} object used in this run.}
+#' }
+#'
+#' @details
+#' The \code{flip_sdr} function implements a sequentially doubly robust estimator for a “flip” intervention:
+#' for each time $t = 1, \dots, \tau$, one either trims units whose estimated density ratio falls below 
+#' \code{trimming_threshold} (with smoothing via \code{smoothing_constant}) or applies overlap weighting 
+#' if \code{overlap = TRUE}.  After estimating all propensity scores via cross‐fitting (in \code{cf_propensity}), 
+#' it computes the density ratios and \(\phi\)-scores (in \code{compute_q_phi_score}), then proceeds
+#' backward from $t = \tau$ to $t = 1$, at each step cross‐fitting a regression of the current pseudo‐outcome
+#' on covariates to update the pseudo‐outcome for the next time step (in \code{cf_sequential_regression}).
+#' The final pseudo‐outcome at time $t = 1$ serves as an influence‐function estimate for the overall flip effect.  
+#'
+#' If \code{life = TRUE}, the returned list also includes \code{$task} and \code{$control} so that 
+#' one can call \code{flip_sdr_second_PO()} or \code{flip_sdr_treatment()} to continue estimation 
+#' under a new target regime or to obtain a treatment‐level effect at a specific final time point, 
+#' but using the same fold and propensity score estimate information.
+#'
+#' @examples
+#' \dontrun{
+#' # Basic usage with smooth trimming:
+#' df <- sim_t4
+#' df$A_1 <- rbinom(n = nrow(df), size = 1, prob = 0.3)
+#' df$A_2 <- rbinom(n = nrow(df), size = 1, prob = 0.5)
+#' df$A_3 <- rbinom(n = nrow(df), size = 1, prob = 0.7)
+#' df$A_4 <- rbinom(n = nrow(df), size = 1, prob = 0.9)
+#' df$X <- runif(n = nrow(df))
+#'
+#'flip_sdr(
+#' data = df,
+#' trt = c("A_1", "A_2", "A_3", "A_4"),
+#' outcome = "Y",
+#' baseline = c("X"),
+#' time_vary = list(c("L_1"), c("L_2"), c("L_3"), c("L_4")),
+#' cens               = NULL,
+#' compete            = NULL,
+#' id = "ID",
+#' target_regime      = rep(1, 4),        # always treat
+#' overlap            = FALSE,
+#' trimming_threshold = 0.1,
+#' smoothing_constant = 5,
+#' outcome_type       = "continuous",
+#' learners_outcome   = "SL.glm",
+#' learners_trt       = "SL.glm",
+#' folds              = 10
+#' )
+#' }
+#'
+#' @export
+flip_sdr <- function(
+    data,
+    trt,
+    outcome,
+    baseline      = NULL,
+    time_vary     = NULL,
+    cens          = NULL,
+    compete       = NULL,
+    target_regime = NULL,
+    overlap       = FALSE,
+    trimming_threshold,
+    smoothing_constant,
+    k             = Inf,
+    outcome_type  = c("binomial","continuous","survival"),
+    id            = NULL,
+    bounds        = NULL,
+    learners_outcome = "SL.glm",
+    learners_trt  = "SL.glm",
+    folds         = 10,
+    weights       = NULL,
+    control       = lmtp_control(),
+    life = FALSE
 ) {
+  
+  # Construct an lmtp task
+  task <- LmtpTask$new(
+    data = data,
+    shifted = data,
+    A = trt,
+    Y = outcome,
+    L = time_vary,
+    W = baseline,
+    C = cens,
+    D = compete,
+    k = k, 
+    id = id,
+    outcome_type = match.arg(outcome_type),
+    folds = folds, 
+    weights = weights,
+    bounds = bounds
+  )
+  
+  # Create progress bar object
+  pb <- progressr::progressor(task$tau * folds * 2)
+  
+  # --- Estimate propensity scores --- #
+  props <- cf_propensity(task, learners_trt, control, pb)
+  
+  # --- Define flip weight and derivative --- # 
+  flip_funcs <- define_flip_functions(overlap, trimming_threshold, smoothing_constant)
+  
+  # --- Compute q scores, ratios, and phi scores --- #
+  scores <- compute_q_phi_scores(
+    task = task,
+    prop_scores = props$prop_scores,
+    target_regime    = target_regime,
+    flip_func        = flip_funcs[[1]],
+    flip_func_deriv  = flip_funcs[[2]]
+  )
 
+  # --- Run sequential regressions with cross-fitting --- #
+  
+  # Initialize array for sequential regression estimates
+  seq_ests <- array(dim = c(nrow(task$natural), task$tau, 2))
+  
+  # Set initial pseudo-outcome equal to actual outcome
+  task$natural$pseudo <- task$natural[, task$vars$Y]
+  fits_m <- vector("list", length = task$tau)
+  
+  # Loop backwards through timepoints
+  for (time in task$tau:1) {
+    
+    # Run cross-fit sequential regressions
+    info <- cf_sequential_regression(task, learners_outcome, control, time, pb)
+    fits_m[[time]] <- info[["fits"]]
+    seq_ests[, time, ] <- info[["seq_reg_ests"]]
+
+    # Construct pseudo outcomes for next round
+    task$natural$pseudo <- eif_flip(task, seq_ests, scores, time, final_time = task$tau)
+  }  
+  
+  # Return outputs!
+  out <- list(
+    estimator = "SDR",
+    ifvalues = task$natural$pseudo,
+    estimate = ife::ife(x = mean(task$natural$pseudo),
+                        eif = task$natural$pseudo,
+                        id = as.character(task$id)),
+    prop_scores = props$prop_scores,
+    fits_prop = props$fits,
+    fits_m = fits_m,
+    outcome_type = task$outcome_type
+  )
+  
+  if (life) {
+    # Add task object to the output
+    out$task <- task
+    out$control <- control
+  }
+  
+  class(out) <- "lmtp"
+  
+  return(out)
 }
+
+#' Internal: second‐stage SDR for potential outcomes
+flip_sdr_second_PO <- function(flip,
+                          target_regime,
+                          overlap,
+                          trimming_threshold,
+                          smoothing_constant,
+                          k,
+                          outcome_type,
+                          id,
+                          bounds,
+                          learners_outcome,
+                          learners_trt,
+                          folds,
+                          weights,
+                          control) {
+  
+  # Create progress bar object
+  pb <- progressr::progressor(flip$task$tau * folds)
+  
+  # --- Define flip weight and derivative --- # 
+  flip_funcs <- define_flip_functions(overlap, trimming_threshold, smoothing_constant)
+  
+  # --- Compute q scores, ratios, and phi scores --- #
+  scores <- compute_q_phi_scores(
+    task = flip$task,
+    prop_scores = flip$prop_scores,
+    target_regime    = target_regime,
+    flip_func        = flip_funcs[[1]],
+    flip_func_deriv  = flip_funcs[[2]]
+  )
+  
+  # --- Run sequential regressions with cross-fitting --- #
+  
+  # Initialize array for sequential regression estimates
+  seq_ests <- array(dim = c(nrow(flip$task$natural), flip$task$tau, 2))
+  
+  # Set initial pseudo-outcome equal to actual outcome
+  flip$task$natural$pseudo <- flip$task$natural[, flip$task$vars$Y]
+  fits_m <- vector("list", length = flip$task$tau)
+  
+  # Loop backwards through timepoints
+  for (time in flip$task$tau:1) {
+    
+    # Run cross-fit sequential regressions
+    info <- cf_sequential_regression(flip$task, learners_outcome, control, time, pb)
+    fits_m[[time]] <- info[["fits"]]
+    seq_ests[, time, ] <- info[["seq_reg_ests"]]
+    
+    # Construct pseudo outcomes for next round
+    flip$task$natural$pseudo <- eif_flip(flip$task, seq_ests, scores, time, final_time = flip$task$tau)
+  }  
+  
+  # Return outputs
+  out <- list(
+    estimator = "SDR",
+    ifvalues = flip$task$natural$pseudo,
+    estimate = ife::ife(x = mean(flip$task$natural$pseudo),
+                        eif = flip$task$natural$pseudo,
+                        id = as.character(flip$task$id)),
+    fits_m = fits_m
+    )
+  
+  class(out) <- "lmtp"
+  
+  return(out)
+}
+
+#' Internal: SDR for estimating average number of treatments
+flip_sdr_treatment <- function(flip,
+                             target_regime,
+                             overlap,
+                             trimming_threshold,
+                             smoothing_constant,
+                             k,
+                             outcome_type,
+                             id,
+                             bounds,
+                             learners_outcome,
+                             folds,
+                             weights,
+                             control,
+                             final_time) {
+  
+  # Progress bar
+  pb <- progressr::progressor((final_time-1) * folds)
+  
+  
+  # --- Define flip weight and derivative --- # 
+  flip_funcs <- define_flip_functions(overlap, trimming_threshold, smoothing_constant)
+  
+  # --- Compute q scores, ratios, and phi scores --- #
+  scores <- compute_q_phi_scores(
+    task = flip$task,
+    prop_scores = flip$prop_scores,
+    target_regime    = target_regime,
+    flip_func        = flip_funcs[[1]],
+    flip_func_deriv  = flip_funcs[[2]]
+  )
+  
+  # --- Run sequential regressions with cross-fitting --- #
+  
+  # Initialize array for sequential regression estimates
+  seq_ests <- array(dim = c(nrow(flip$task$natural), final_time-1, 2))
+  
+  # Set initial pseudo-outcome equal to actual outcome
+  flip$task$natural$pseudo <- pmax(0, pmin(1, scores$q_scores[, final_time] + scores$phi_scores[, final_time, 2]))
+  flip$task$natural[, flip$task$vars$Y] <- flip$task$natural$pseudo
+  fits_m <- vector("list", length = final_time-1)
+  
+  # Loop backwards through timepoints
+  if (final_time > 1) {
+    for (time in (final_time-1):1) {
+      
+      # Run cross-fit sequential regressions
+      info <- cf_sequential_regression(flip$task, learners_outcome, control, time, pb)
+      fits_m[[time]] <- info[["fits"]]
+      seq_ests[, time, ] <- info[["seq_reg_ests"]]
+      
+      # Construct pseudo outcomes for next round
+      flip$task$natural$pseudo <- eif_flip(flip$task, seq_ests, scores, time, final_time = final_time-1)
+    }  
+  }
+  
+  # Return outputs
+  out <- list(
+    estimator = "SDR",
+    ifvalues = flip$task$natural$pseudo,
+    estimate = ife::ife(x = mean(flip$task$natural$pseudo),
+                        eif = flip$task$natural$pseudo,
+                        id = as.character(flip$task$id)),
+    fits_m = fits_m
+  )
+  
+  class(out) <- "lmtp"
+  
+  return(out)
+}
+
+
+

--- a/R/life_sdr.R
+++ b/R/life_sdr.R
@@ -1,0 +1,255 @@
+#' @title Longitudinal Interventional Flip Effect SDR Estimator
+#' @description
+#' Estimate the longitudinal interventional flip effect comparing always‐treated versus never‐treated
+#' using a sequentially doubly robust (SDR) procedure with either smooth trimming or overlap weighting.
+#'
+#' @param data               A \code{data.frame} containing all variables.
+#' @param trt                Character vector of treatment column names (time‐varying, each ending in \code{"_tXX"}).
+#' @param outcome            Name of the outcome column (character).
+#' @param baseline           Character vector of baseline covariate names, or \code{NULL}.
+#' @param time_vary          Character vector of time‐varying covariate names (each ending in \code{"_tXX"}), or \code{NULL}.
+#' @param cens               Name of the censoring indicator column (character), or \code{NULL}.
+#' @param compete            Name of the competing event indicator column (character), or \code{NULL}.
+#' @param overlap            Logical; if \code{TRUE}, use overlap weights at each time point, otherwise use smooth trimming.
+#' @param trimming_threshold Numeric threshold for trimming (or weight cutoff) when \code{overlap = FALSE}.
+#' @param smoothing_constant Numeric smoothing parameter (larger → weight function closer to a hard indicator).
+#' @param k                  Integer (or \code{Inf}); history‐window size for the underlying \code{LmtpTask}.
+#'                           If \code{Inf}, use the full treatment history.
+#' @param outcome_type       Character; one of \code{c("binomial","continuous","survival")}.
+#'                           Determines whether pseudo‐outcomes are bounded.
+#' @param id                 Name of the subject‐identifier column (character), or \code{NULL}.
+#' @param bounds             Optional numeric vector of length 2 (\code{c(lower, upper)}) giving outcome bounds.
+#'                           If \code{NULL}, no bounding is applied on any regression fits.
+#' @param learners_outcome   Character vector of SuperLearner (or other) learners for sequential outcome regressions.
+#' @param learners_trt       Character vector of SuperLearner (or other) learners for time‐varying treatment models.
+#' @param folds              Integer ≥ 2; number of cross‐fitting folds for propensity and outcome regressions.
+#' @param weights            Optional numeric vector of sample weights (length = \code{nrow(data)}).
+#'                           If \code{NULL}, no sample weighting is applied.
+#' @param control            An \code{lmtp_control} object controlling learner options and parallelization.
+#' @param num_timepoints     Integer; total number of time points (i.e.\ \(\tau\)). Used for loops over times.
+#'
+#' @return A list with class \code{life}, containing:
+#' \describe{
+#'   \item{\code{estimator}}{Character; the string \code{"SDR"}, indicating the estimator used.}
+#'   \item{\code{ifvalues}}{Numeric vector of length \(n\), giving the final influence‐function values
+#'                          (ratio of always‐ vs never‐treated flip effects).}
+#'   \item{\code{estimate}}{An \code{\link[ife]{ife}} object with \code{x =} point estimate of
+#'                          the flip‐effect ratio and \code{eif = ifvalues}.}
+#'   \item{\code{auxiliary_info}}{A list containing:
+#'     \itemize{
+#'       \item{\code{always_treated_avg_PO}}{Result of \code{flip_sdr} under always‐treated regime.}
+#'       \item{\code{never_treated_avg_PO}}{Result of \code{flip_sdr_second_PO} under never‐treated regime.}
+#'       \item{\code{always_treated_avg_tx}}{List of \code{flip_sdr_treatment} outputs for each time \(t\) under always‐treated.}
+#'       \item{\code{never_treated_avg_tx}}{List of \code{flip_sdr_treatment} outputs for each time \(t\) under never‐treated.}
+#'     }
+#'   }
+#' }
+#'
+#' @details
+#' This function estimates the longitudinal interventional flip effects of 
+#' (1) always‐treated versus (2) never‐treated. Internally:
+#' \enumerate{
+#'   \item It calls \code{flip_sdr(..., target_regime = rep(1, num_timepoints), life = TRUE)} 
+#'         to estimate the average potential outcome when everyone is flipped towards treatment
+#'         at all times (via smooth trimming or overlap weighting) and stores the resulting
+#'         \code{flip} object as \code{always_treated_avg_PO}.
+#'   \item It loops backward through \(\{\,\tau, \dots, 1\,\}\), calling
+#'         \code{flip_sdr_treatment(always_treated_avg_PO, final_time = t)} to compute the
+#'         average number of treatments at each time \(t\) under always‐treated; stored in
+#'         \code{always_treated_avg_tx}.
+#'   \item It calls \code{flip_sdr_second_PO(always_treated_avg_PO, target_regime = rep(0, num_timepoints))} 
+#'         to estimate the average potential outcome when everyone is flipped towards control
+#'         (smooth trimming or overlap weighting under never treated); stored as \code{never_treated_avg_PO}.
+#'   \item It loops backward again, calling
+#'         \code{flip_sdr_treatment(always_treated_avg_PO, target_regime = rep(0, num_timepoints), final_time = t)}
+#'         to compute the average number of treatments at each time \(t\) under never‐treated;
+#'         stored in \code{never_treated_avg_tx}.
+#'   \item Finally, it returns influence function estimates for the longitudinal interventional
+#'         flip effect alongside auxiliary info from previous steps, including the estimates 
+#'         for the difference in number of treatments at each timepoint
+#' }
+#' 
+#' @examples
+#' \dontrun{
+#' # Suppose you have 4 time points and want to compare always vs never treat:
+#' mydata <- sim_t4
+#' mydata$A_1 <- rbinom(n = nrow(mydata), size = 1, prob = 0.3)
+#' mydata$A_2 <- rbinom(n = nrow(mydata), size = 1, prob = 0.5)
+#' mydata$A_3 <- rbinom(n = nrow(mydata), size = 1, prob = 0.7)
+#' mydata$A_4 <- rbinom(n = nrow(mydata), size = 1, prob = 0.9)
+#' mydata$X <- runif(n = nrow(mydata))
+#' test2 <- life_sdr(
+#'   data = df, 
+#'   trt = c("A_1", "A_2", "A_3", "A_4"),
+#'   outcome = "Y",
+#'   baseline = c("X"),
+#'   time_vary = list(c("L_1"), c("L_2"), c("L_3"), c("L_4")),
+#'   cens               = NULL,
+#'   compete            = NULL,
+#'   id = "ID",
+#'   overlap            = FALSE,
+#'   trimming_threshold = 0.1,
+#'   smoothing_constant = 5,
+#'   outcome_type       = "continuous",
+#'   learners_outcome   = "SL.glm",
+#'   learners_trt       = "SL.glm",
+#'   folds              = 10,
+#'   num_timepoints = 4
+#'   )
+#' }
+#'
+#' @export
+life_sdr <- function(
+    data,
+    trt,
+    outcome,
+    baseline      = NULL,
+    time_vary     = NULL,
+    cens          = NULL,
+    compete       = NULL,
+    overlap       = FALSE,
+    trimming_threshold,
+    smoothing_constant,
+    k             = Inf,
+    outcome_type  = c("binomial","continuous","survival"),
+    id            = NULL,
+    bounds        = NULL,
+    learners_outcome = "SL.glm",
+    learners_trt  = "SL.glm",
+    folds         = 10,
+    weights       = NULL,
+    control       = lmtp_control(),
+    num_timepoints
+) {
+  
+  always_treated <- flip_sdr(
+    data = data, 
+    trt = trt, 
+    outcome = outcome,
+    baseline = baseline,
+    time_vary = time_vary,
+    cens = cens,
+    compete = compete,
+    id = id,
+    target_regime = rep(1, num_timepoints), # always treat
+    overlap = overlap,
+    trimming_threshold = trimming_threshold,
+    smoothing_constant = smoothing_constant,
+    outcome_type       = outcome_type,
+    learners_outcome   = learners_outcome,
+    learners_trt       = learners_trt,
+    folds              = folds,
+    life = T
+  )
+  
+  # Construct estimates for average number of treatments under always treated
+  # Re-use information from first run (e.g., propensity score estimates, 
+  # fold assignments, id, etc.)
+  always_avg_treatments <- vector("list", length = num_timepoints) 
+  for (time in num_timepoints:1) {
+    always_avg_treatments[[time]] <-
+      flip_sdr_treatment(always_treated,
+                       target_regime = rep(1, num_timepoints),
+                       overlap,
+                       trimming_threshold,
+                       smoothing_constant,
+                       k,
+                       outcome_type,
+                       id,
+                       bounds,
+                       learners_outcome,
+                       folds,
+                       weights,
+                       control,
+                       final_time = time) 
+  }
+  
+  # Estimate mean potential outcome (and re-use information from first run)
+  never_treated <- flip_sdr_second_PO(
+    flip = always_treated,
+    target_regime = rep(0, num_timepoints), # never treated
+    overlap,
+    trimming_threshold,
+    smoothing_constant,
+    k,
+    outcome_type,
+    id,
+    bounds,
+    learners_outcome,
+    learners_trt,
+    folds,
+    weights,
+    control) 
+  
+  # Construct estimates for average number of treatments under never treated
+  #  (and re-use information from first run)
+  never_avg_treatments <- vector("list", length = num_timepoints) 
+  for (time in num_timepoints:1) {
+    never_avg_treatments[[time]] <-
+      flip_sdr_treatment(always_treated,
+                       target_regime = rep(0, num_timepoints),
+                       overlap,
+                       trimming_threshold,
+                       smoothing_constant,
+                       k,
+                       outcome_type,
+                       id,
+                       bounds,
+                       learners_outcome,
+                       folds,
+                       weights,
+                       control,
+                       final_time = time) 
+  }
+
+  # Compute numerator IFs and point estimate (always_avg_PO - never_avg_PO)
+  num_ifs <- always_treated$ifvalues - never_treated$ifvalues
+  num_est <- mean(num_ifs)
+
+  # Compute denominator: average per-timepoint absolute change in treatment
+  trt_diff_info <- data.frame()
+  denom_est <- 0
+  denom_ifs <- rep(0, length(id))
+  for (t in 1:always_treated$task$tau) {
+    
+    always_ifvalues <- always_avg_treatments[[t]]$ifvalues
+    never_ifvalues  <- never_avg_treatments[[t]]$ifvalues
+    
+    this_time_est <- abs(mean(always_ifvalues - never_ifvalues)) 
+    this_time_ifs <- sign(mean(always_ifvalues - never_ifvalues)) * 
+      (always_ifvalues - never_ifvalues)
+    
+    denom_est <- denom_est + this_time_est / always_treated$task$tau
+    denom_ifs <- denom_ifs + this_time_ifs / always_treated$task$tau
+    
+    trt_diff_info <- rbind(trt_diff_info, 
+      data.frame(
+        t = t,
+        ptest = this_time_est,
+        sdest = sd(this_time_ifs) / sqrt(length(this_time_ifs))
+      )
+    )
+  }
+  
+  # Form ratio influence‐function and return
+  ratio_ifs <- num_ifs / denom_est - (num_est / denom_est^2) * denom_ifs 
+  
+  return(
+    list(
+      estimator = "SDR",
+      ifvalues = ratio_ifs,
+      estimate =   ife::ife(x = num_est / denom_est,
+                            eif = ratio_ifs,
+                            id = as.character(always_treated$task$id)),
+      auxiliary_info = list(
+        trt_diff_info = trt_diff_info,
+        always_treated_avg_PO = always_treated,
+        never_treated_avg_PO = never_treated,
+        always_treated_avg_tx = always_avg_treatments,
+        never_treated_avg_tx = never_avg_treatments
+      )
+    )
+  )
+}
+
+

--- a/R/propensity.R
+++ b/R/propensity.R
@@ -1,0 +1,105 @@
+#' @keywords internal
+#' @title Cross‐fitted propensity score estimation
+#' @description
+#' Perform V‐fold cross‐validation to estimate time‐varying propensity scores.
+#'
+#' @param task     An `lmtp_task` object created by `lmtp_task()`.
+#' @param learners Character; either "rf" (ranger) or "sl" (SuperLearner).
+#' @param control  An `lmtp_control()` object; supplies `.learners_trt_folds` and `.quiet`.
+#' @param pb       Function; optional progress callback called after each timepoint.
+#'
+#' @return A list with:
+#'   \item{prop_scores}{Array of dimension (n_valid × T × 2): P(A_t=0) in [,,1], P(A_t=1) in [,,2].}
+#'   \item{fits}{List of length T with fitted model objects or weights.}
+cf_propensity <- function(task, learners, control, pb = NULL) {
+  folds <- task$folds
+  nf    <- length(folds)
+  ans   <- vector("list", length = nf)
+  
+  for (f in seq_len(nf)) {
+    ans[[f]] <- future::future({
+      estimate_propensity(task, f, learners, control, pb)
+    }, seed = TRUE)
+  }
+  ans <- future::value(ans)
+  
+  prop_list <- lapply(ans, function(x) x$prop_scores)
+  prop_scores <- recombine(rbind_depth(prop_list, NULL), folds)
+  fits <- lapply(ans, function(x) x$fits)
+  
+  list(prop_scores = prop_scores, fits = fits)
+}
+
+#' @keywords internal
+#' @title Fold‐specific propensity score estimation
+#' @description
+#' Estimate time‐varying propensity scores within a single cross‐fit fold, 
+#' fitting only on at‐risk subjects.
+#'
+#' @inheritParams cf_propensity
+#' @param fold Integer index of the fold to use as evaluation set.
+#'
+#' @return A list with:
+#'   \item{prop_scores}{Array (n_valid × T × 2) of estimated propensities on validation set.}
+#'   \item{fits}{List of length T of fitted models or weight vectors.}
+estimate_propensity <- function(task, fold, learners, control, pb = NULL) {
+  
+  # Pull natural train/validation splits
+  natural    <- get_folded_data(task$natural, task$folds, fold)
+  train_data <- natural$train
+  valid_data <- natural$valid
+  
+  n_valid <- nrow(valid_data)
+  # Only estimate for timepoints with treatment data
+  T_trt   <- length(task$vars$A)
+  
+  # Initialize outputs
+  prop_scores <- array(NA_real_, dim = c(n_valid, T_trt, 2))
+  fits        <- vector("list", T_trt)
+  
+  baseline <- task$baseline
+  id_var   <- task$vars$id
+  
+  for (t in seq_len(T_trt)) {
+    
+    # Treatment at time t
+    A_t <- task$vars$A[[t]]
+    
+    # At-risk subset indices
+    train_idx <- ii(task$observed(train_data, t - 1), task$R(train_data, t))
+    valid_idx <- ii(task$observed(valid_data, t - 1), task$R(valid_data, t))
+    
+    # Predictors: baseline + treatment history up to t-1 + time‐varying covariates up to t
+    pred_cols <- c(
+      baseline,
+      task$vars$history("A", t),
+      task$vars$history("L", t + 1)
+    )
+    
+    # Training data frame
+    train_df <- train_data[train_idx, c(id_var, pred_cols, A_t), drop = FALSE]
+    
+    # Fit propensity model
+    fit <- run_ensemble(
+      data     = train_df,
+      outcome  = A_t,
+      learners = learners,
+      family   = "binomial",
+      id       = id_var,
+      folds    = control$.learners_trt_folds
+    )
+    fits[[t]] <- if (control$.return_full_fits) fit else extract_sl_weights(fit)
+    
+    # Validation data frame and predictions
+    valid_df <- valid_data[valid_idx, c(id_var, pred_cols, A_t), drop = FALSE]
+    preds    <- predict(fit, valid_df)
+    
+    # Store P(A_t=1 | H_t) and P(A_t=0 | H_t)
+    prop_scores[valid_idx, t, 2] <- preds
+    prop_scores[valid_idx, t, 1] <- 1 - preds
+    
+    if (!is.null(pb)) pb()
+  }
+  
+  list(prop_scores = prop_scores, fits = fits)
+}


### PR DESCRIPTION
### Summary

This PR implements a sequentially doubly robust (SDR) estimator for the flip effect and the longitudinal interventional flip effect (comparing always-treated vs. never-treated regimes). The estimator supports both smooth trimming and overlap weighting.

### Key changes

- Adds `flip_sdr()` and `life_sdr()` functions that are user-facing. `flip_sdr` estimate the flip effect under targeting a specific regime. `life_sdr` calculates the longitudinal interventional flip effect of always treated versus never treated.
- Adds cross-fit propensity score estimation with binary treatment in propensity.R
- Adds additional internal helper functions:
-- Efficient influence function calculation for flip interventions
-- Wrapper for sequential regression, cf_sequential_regression(), that does cross-fitting within each timepoint
-- `estimate_flip_sdr()`, which runs sequential regression for flip effects
-- `flip_sdr_treatment()`, which estimates average number of treatments at a given timepoint under a flip intervention
-- `flip_sdr_second_PO()`, which estimates mean potential outcomes under a flip intervention, but uses previous lmtp task information to avoid re-running, e.g., propensity score estimation.
- Integrates with existing LMTP-style workflow (e.g., `LmtpTask` class)

### Notes

- The estimator assumes consistent column naming (`_tXX` suffix) for time-varying treatments and covariates
- The `overlap` option toggles between smooth trimming and overlap weighting
- With smooth trimming, the weight is only constructed with respect to the target regime. Future work could incorporate symmetric weights.