### PR TITLE
Fix multivariate exposure support for lmtp_survival

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -57,7 +57,14 @@ check_trt_list <- function(trt, tau) {
 assert_trt_list <- checkmate::makeAssertionFunction(check_trt_list)
 
 check_shifted_data <- function(natural, shifted, trt, cens) {
-  is_same <- setdiff(names(natural), c(trt, cens))
+  # Handle when trt is a list (multivariate treatments)
+  if (is.list(trt)) {
+    trt_cols <- unlist(trt)
+  } else {
+    trt_cols <- trt
+  }
+
+  is_same <- setdiff(names(natural), c(trt_cols, cens))
 
   if (!(identical(natural[is_same], shifted[is_same]))) {
     return("The only columns that can be different between `data` and `shifted` are those indicated in `trt` and `cens`")

--- a/R/lmtp_survival.R
+++ b/R/lmtp_survival.R
@@ -95,14 +95,25 @@ lmtp_survival <- function(data, trt, outcomes, baseline = NULL, time_vary = NULL
     control = control
   )
 
-  if (length(trt) == 1) args$trt <- trt
-  if (length(time_vary) == 1) args$time_vary <- time_vary
+  # Handle treatment assignment based on whether it's time-varying or not
+  is_time_varying_trt <- length(trt) > 1 && !is.list(trt)
+  if (is_time_varying_trt || length(trt) == 1) {
+    args$trt <- trt
+  }
+
+  if (length(time_vary) == 1) {
+    args$time_vary <- time_vary
+  }
 
   time <- 1
   cli::cli_progress_step("Working on time {time}/{time_horizon}...")
   for (time in seq_len(time_horizon)) {
-    if (length(trt) > 1) args$trt <- trt[seq_len(time)]
-    if (length(args$time_vary) > 1) args$time_vary <- time_vary[seq_len(time)]
+    if (is_time_varying_trt) {
+      args$trt <- trt[seq_len(time)]
+    }
+    if (length(args$time_vary) > 1) {
+      args$time_vary <- time_vary[seq_len(time)]
+    }
     args$outcome <- outcomes[seq_len(time)]
     args$cens <- cens[seq_len(time)]
     args$compete <- compete[seq_len(time)]


### PR DESCRIPTION
      - Fix check_shifted_data to properly handle list treatment variables by
        using unlist() to flatten multivariate treatment column names
      - Update lmtp_survival to distinguish between time-varying treatments
        (character vector) and multivariate treatments (list) to prevent
        incorrect time subsetting of multivariate exposures
      - Resolves error when using list(c(trt1, trt2)) format for
        simultaneous multivariate interventions in survival analysis

Addresses #175 